### PR TITLE
Fix the handler

### DIFF
--- a/Sources/EventMiddleware/ErrorEventMiddleware.swift
+++ b/Sources/EventMiddleware/ErrorEventMiddleware.swift
@@ -2,7 +2,7 @@ import Aftermath
 
 public struct ErrorEventMiddleware: EventMiddleware {
 
-  public typealias Handler = (AnyEvent, Failure) -> Void
+  public typealias Handler = (AnyEvent, Error) -> Void
 
   public var handler: Handler = { event in
     log("Event failed with error -> \(event)")
@@ -18,7 +18,7 @@ public struct ErrorEventMiddleware: EventMiddleware {
     do {
       try next(event)
     } catch {
-      handler(event, error as! Failure)
+      handler(event, error)
       throw error
     }
   }


### PR DESCRIPTION
For some reasons, I get `Aftermath.Warning` instead of `Aftermath.Failure`, and this cast could crash the app. This fixes by passing `Error` as it is